### PR TITLE
New: Add Google analytics tracking code to sites

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -13,4 +13,15 @@
     <script src="{{ site.baseurl }}/assets/js/bulma-collapsible.min.js" type="text/javascript"></script>
 
     {% seo %}
+    {% if site.google_analytics_id %}
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics_id }}"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+
+        gtag('config', '{{ site.google_analytics_id }}');
+    </script>
+    {% endif %}
 </head>

--- a/rism-theme.gemspec
+++ b/rism-theme.gemspec
@@ -2,9 +2,9 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "rism-theme"
-  spec.version       = "0.1.53"
-  spec.authors       = ["Rodolfo Zitellini", "Andrew Hankinson"]
-  spec.email         = ["rodolfo.zitellini@rism-ch.org", "andrew.hankinson@rism.digital"]
+  spec.version       = "0.1.54"
+  spec.authors       = ["Rodolfo Zitellini", "Andrew Hankinson", "Laurent Pugin"]
+  spec.email         = ["rodolfo.zitellini@rism-ch.org", "andrew.hankinson@rism.digital", "laurent.pugin@rism.digital"]
 
   spec.summary       = "Shared theme for RISM websites."
   spec.homepage      = "http://www.rism.info"


### PR DESCRIPTION
If the site configuration contains the 'google_analytics_id' option, the theme will include the necessary code for Google Analytics tracking.

Also updates the authors list and increments the version number.