### PR TITLE
Fixed: Change the font for RISM websites

### DIFF
--- a/_sass/rism-theme.scss
+++ b/_sass/rism-theme.scss
@@ -1,6 +1,8 @@
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap');
+
 $primary: #004f8f;
 $link: #0570c9;
-$family-primary: "Helvetica Neue", "Helvetica", "Arial", sans-serif;
+$family-primary: "Noto Sans", "Helvetica", "Arial", sans-serif;
 $body-font-size: 15px;
 $footer-padding: 1rem 1.5rem 1rem;
 

--- a/rism-theme.gemspec
+++ b/rism-theme.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "rism-theme"
-  spec.version       = "0.1.71"
+  spec.version       = "0.1.72"
   spec.authors       = ["Rodolfo Zitellini", "Andrew Hankinson", "Laurent Pugin"]
   spec.email         = ["rodolfo.zitellini@rism-ch.org", "andrew.hankinson@rism.digital", "laurent.pugin@rism.digital"]
 


### PR DESCRIPTION
In order to help differentiate between certain characters, it was decided to change the fonts of all RISM websites to the Noto font.

This commit changes the font in the shared rism-theme.